### PR TITLE
[ECO-4968] Added missed `NS_SWIFT_SENDABLE`

### DIFF
--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -299,6 +299,12 @@
 		844B9CCF2C807BC400A260E8 /* ARTDeviceDetails+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 844B9CCE2C807BC400A260E8 /* ARTDeviceDetails+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		844B9CD02C807BC400A260E8 /* ARTDeviceDetails+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 844B9CCE2C807BC400A260E8 /* ARTDeviceDetails+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		844B9CD12C807BC400A260E8 /* ARTDeviceDetails+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 844B9CCE2C807BC400A260E8 /* ARTDeviceDetails+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		845381F42C930A8C0085834E /* ARTBaseQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 845381F32C930A8C0085834E /* ARTBaseQuery.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		845381F52C930A8C0085834E /* ARTBaseQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 845381F32C930A8C0085834E /* ARTBaseQuery.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		845381F62C930A8C0085834E /* ARTBaseQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 845381F32C930A8C0085834E /* ARTBaseQuery.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		845381F82C930B9D0085834E /* ARTBaseQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = 845381F72C930B9D0085834E /* ARTBaseQuery.m */; };
+		845381F92C930B9D0085834E /* ARTBaseQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = 845381F72C930B9D0085834E /* ARTBaseQuery.m */; };
+		845381FA2C930B9D0085834E /* ARTBaseQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = 845381F72C930B9D0085834E /* ARTBaseQuery.m */; };
 		848ED97326E50D0F0087E800 /* ObjcppTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 848ED97226E50D0F0087E800 /* ObjcppTest.mm */; settings = {COMPILER_FLAGS = "-fmodules"; }; };
 		848ED97426E50D0F0087E800 /* ObjcppTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 848ED97226E50D0F0087E800 /* ObjcppTest.mm */; settings = {COMPILER_FLAGS = "-fmodules"; }; };
 		848ED97526E50D0F0087E800 /* ObjcppTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 848ED97226E50D0F0087E800 /* ObjcppTest.mm */; settings = {COMPILER_FLAGS = "-fmodules"; }; };
@@ -1245,6 +1251,8 @@
 		8412FDE32661AC37001FE9E6 /* msgpack.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = msgpack.xcframework; path = Carthage/Build/msgpack.xcframework; sourceTree = "<group>"; };
 		8412FDF42661AC7B001FE9E6 /* Nimble.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Nimble.xcframework; path = Carthage/Build/Nimble.xcframework; sourceTree = "<group>"; };
 		844B9CCE2C807BC400A260E8 /* ARTDeviceDetails+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "ARTDeviceDetails+Private.h"; path = "PrivateHeaders/Ably/ARTDeviceDetails+Private.h"; sourceTree = "<group>"; };
+		845381F32C930A8C0085834E /* ARTBaseQuery.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARTBaseQuery.h; path = include/Ably/ARTBaseQuery.h; sourceTree = "<group>"; };
+		845381F72C930B9D0085834E /* ARTBaseQuery.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTBaseQuery.m; sourceTree = "<group>"; };
 		848ED97226E50D0F0087E800 /* ObjcppTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ObjcppTest.mm; sourceTree = "<group>"; };
 		850BFB4A1B79323C009D0ADD /* ARTPaginatedResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARTPaginatedResult.h; path = include/Ably/ARTPaginatedResult.h; sourceTree = "<group>"; };
 		850BFB4B1B79323C009D0ADD /* ARTPaginatedResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTPaginatedResult.m; sourceTree = "<group>"; };
@@ -2125,6 +2133,8 @@
 				96BF61571A35B52C004CF2B3 /* ARTHttp.m */,
 				D7588AF11BFF91B800BB8279 /* ARTURLSessionServerTrust.h */,
 				D7588AF21BFF91B800BB8279 /* ARTURLSessionServerTrust.m */,
+				845381F32C930A8C0085834E /* ARTBaseQuery.h */,
+				845381F72C930B9D0085834E /* ARTBaseQuery.m */,
 				D746AE1A1BBB5207003ECEF8 /* ARTDataQuery.h */,
 				D746AE1B1BBB5207003ECEF8 /* ARTDataQuery+Private.h */,
 				D746AE1C1BBB5207003ECEF8 /* ARTDataQuery.m */,
@@ -2232,6 +2242,7 @@
 				EB91213E1CA0AD6600BA0A40 /* ARTMsgPackEncoder.h in Headers */,
 				96A507BD1A3791490077CDF8 /* ARTRealtime.h in Headers */,
 				21088DC32A5354F10033C722 /* ARTConnectRetryState.h in Headers */,
+				845381F42C930A8C0085834E /* ARTBaseQuery.h in Headers */,
 				EB5E058D1C77027600A48B39 /* ARTCrypto+Private.h in Headers */,
 				2132C2F529D5BE05000C4355 /* ARTRetrySequence.h in Headers */,
 				D72C67DF201AB74000978EBB /* ARTPushActivationStateMachine+Private.h in Headers */,
@@ -2472,6 +2483,7 @@
 				D710D4A921949ADF008F54AD /* ARTRestChannels.h in Headers */,
 				D710D4D821949BF9008F54AD /* ARTRealtimePresence.h in Headers */,
 				D710D48F21949AAE008F54AD /* ARTRest.h in Headers */,
+				845381F52C930A8C0085834E /* ARTBaseQuery.h in Headers */,
 				D710D5B821949D4F008F54AD /* ARTAuthOptions+Private.h in Headers */,
 				2124B79429DB13C400AD8361 /* ARTInternalLog.h in Headers */,
 				D710D51D21949C42008F54AD /* ARTDeviceStorage.h in Headers */,
@@ -2642,6 +2654,7 @@
 				D710D4AF21949AE0008F54AD /* ARTRestChannels.h in Headers */,
 				D710D4E821949BFB008F54AD /* ARTRealtimePresence.h in Headers */,
 				D710D49121949AAF008F54AD /* ARTRest.h in Headers */,
+				845381F62C930A8C0085834E /* ARTBaseQuery.h in Headers */,
 				D710D5C821949D50008F54AD /* ARTAuthOptions+Private.h in Headers */,
 				2124B79529DB13C400AD8361 /* ARTInternalLog.h in Headers */,
 				D710D52F21949C44008F54AD /* ARTDeviceStorage.h in Headers */,
@@ -3177,6 +3190,7 @@
 				D7DF738B1EA645300013CD36 /* ARTLocalDeviceStorage.m in Sources */,
 				D7B621911E4A6E0200684474 /* ARTPush.m in Sources */,
 				D70C36C6233E6831002FD6E3 /* ARTFormEncode.m in Sources */,
+				845381F82C930B9D0085834E /* ARTBaseQuery.m in Sources */,
 				D7AE18D31E5B410F00478D82 /* ARTPushChannelSubscriptions.m in Sources */,
 				1CD8DCA01B1C7315007EAF36 /* ARTDefault.m in Sources */,
 				211A610729DA05D700D169C5 /* ARTAttachRequestParams.m in Sources */,
@@ -3417,6 +3431,7 @@
 				D710D5D621949D78008F54AD /* ARTChannel.m in Sources */,
 				D70C36C7233E6831002FD6E3 /* ARTFormEncode.m in Sources */,
 				D710D5D121949D78008F54AD /* ARTAuthDetails.m in Sources */,
+				845381F92C930B9D0085834E /* ARTBaseQuery.m in Sources */,
 				D710D4EC21949C0D008F54AD /* ARTRealtime.m in Sources */,
 				D710D4ED21949C0D008F54AD /* ARTRealtimeChannel.m in Sources */,
 				211A610829DA05D700D169C5 /* ARTAttachRequestParams.m in Sources */,
@@ -3541,6 +3556,7 @@
 				D70C36C8233E6831002FD6E3 /* ARTFormEncode.m in Sources */,
 				D710D5F721949D79008F54AD /* ARTAuthDetails.m in Sources */,
 				D710D4FC21949C0E008F54AD /* ARTRealtime.m in Sources */,
+				845381FA2C930B9D0085834E /* ARTBaseQuery.m in Sources */,
 				D710D4FD21949C0E008F54AD /* ARTRealtimeChannel.m in Sources */,
 				D710D65621949E77008F54AD /* ARTNSDictionary+ARTDictionaryUtil.m in Sources */,
 				211A610929DA05D700D169C5 /* ARTAttachRequestParams.m in Sources */,

--- a/Source/ARTBaseQuery.m
+++ b/Source/ARTBaseQuery.m
@@ -1,4 +1,13 @@
 #import "ARTBaseQuery.h"
 
 @implementation ARTBaseQuery
+
+- (void)throwIfFrozen {
+    if (self.isFrozen) {
+        @throw [NSException exceptionWithName:NSObjectInaccessibleException
+                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
+                                     userInfo:nil];
+    }
+}
+
 @end

--- a/Source/ARTBaseQuery.m
+++ b/Source/ARTBaseQuery.m
@@ -1,0 +1,4 @@
+#import "ARTBaseQuery.h"
+
+@implementation ARTBaseQuery
+@end

--- a/Source/ARTDataEncoder.m
+++ b/Source/ARTDataEncoder.m
@@ -97,6 +97,9 @@
             encoded = [data dataUsingEncoding:NSUTF8StringEncoding];
             encoding = [NSString artAddEncoding:@"utf-8" toString:encoding];
         }
+        if (encoded == nil) {
+            return [[ARTDataEncoderOutput alloc] initWithData:data encoding:nil errorInfo:[ARTErrorInfo createWithCode:0 message:@"must be NSString, NSData, NSArray or NSDictionary."]];
+        }
         ARTStatus *status = [_cipher encrypt:encoded output:&toBase64];
         if (status.state != ARTStateOk) {
             ARTErrorInfo *errorInfo = status.errorInfo ? status.errorInfo : [ARTErrorInfo createWithCode:0 message:@"encrypt failed"];
@@ -181,7 +184,7 @@
             if (status.state != ARTStateOk) {
                 errorInfo = status.errorInfo ? status.errorInfo : [ARTErrorInfo createWithCode:ARTErrorInvalidMessageDataOrEncoding message:@"decrypt failed"];
             }
-        } else if ([encoding isEqualToString:@"vcdiff"] && _deltaCodec) {
+        } else if ([encoding isEqualToString:@"vcdiff"] && _deltaCodec && [data isKindOfClass:[NSData class]]) {
             NSError *decodeError;
             data = [_deltaCodec applyDelta:data deltaId:identifier baseId:_baseId error:&decodeError];
 

--- a/Source/ARTDataQuery.m
+++ b/Source/ARTDataQuery.m
@@ -48,11 +48,7 @@ static NSString *queryDirectionToString(ARTQueryDirection direction) {
 }
 
 - (void)setStart:(NSDate *)value {
-    if (self.isFrozen) {
-        @throw [NSException exceptionWithName:NSObjectInaccessibleException
-                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
-                                     userInfo:nil];
-    }
+    [self throwIfFrozen];
     _start = value;
 }
 
@@ -61,11 +57,7 @@ static NSString *queryDirectionToString(ARTQueryDirection direction) {
 }
 
 - (void)setEnd:(NSDate *)value {
-    if (self.isFrozen) {
-        @throw [NSException exceptionWithName:NSObjectInaccessibleException
-                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
-                                     userInfo:nil];
-    }
+    [self throwIfFrozen];
     _end = value;
 }
 
@@ -74,11 +66,7 @@ static NSString *queryDirectionToString(ARTQueryDirection direction) {
 }
 
 - (void)setLimit:(uint16_t)value {
-    if (self.isFrozen) {
-        @throw [NSException exceptionWithName:NSObjectInaccessibleException
-                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
-                                     userInfo:nil];
-    }
+    [self throwIfFrozen];
     _limit = value;
 }
 
@@ -87,11 +75,7 @@ static NSString *queryDirectionToString(ARTQueryDirection direction) {
 }
 
 - (void)setDirection:(ARTQueryDirection)value {
-    if (self.isFrozen) {
-        @throw [NSException exceptionWithName:NSObjectInaccessibleException
-                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
-                                     userInfo:nil];
-    }
+    [self throwIfFrozen];
     _direction = value;
 }
 
@@ -122,11 +106,7 @@ static NSString *queryDirectionToString(ARTQueryDirection direction) {
 }
 
 - (void)setUntilAttach:(BOOL)value {
-    if (self.isFrozen) {
-        @throw [NSException exceptionWithName:NSObjectInaccessibleException
-                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
-                                     userInfo:nil];
-    }
+    [self throwIfFrozen];
     _untilAttach = value;
 }
 

--- a/Source/ARTDataQuery.m
+++ b/Source/ARTDataQuery.m
@@ -1,7 +1,12 @@
 #import "ARTDataQuery+Private.h"
 #import "ARTRealtimeChannel+Private.h"
 
-@implementation ARTDataQuery
+@implementation ARTDataQuery {
+    NSDate *_start;
+    NSDate *_end;
+    uint16_t _limit;
+    ARTQueryDirection _direction;
+}
 
 - (instancetype)init {
     if (self = [super init]) {
@@ -38,9 +43,63 @@ static NSString *queryDirectionToString(ARTQueryDirection direction) {
     return items;
 }
 
+- (NSDate *)start {
+    return _start;
+}
+
+- (void)setStart:(NSDate *)value {
+    if (self.isFrozen) {
+        @throw [NSException exceptionWithName:NSObjectInaccessibleException
+                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
+                                     userInfo:nil];
+    }
+    _start = value;
+}
+
+- (NSDate *)end {
+    return _end;
+}
+
+- (void)setEnd:(NSDate *)value {
+    if (self.isFrozen) {
+        @throw [NSException exceptionWithName:NSObjectInaccessibleException
+                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
+                                     userInfo:nil];
+    }
+    _end = value;
+}
+
+- (uint16_t)limit {
+    return _limit;
+}
+
+- (void)setLimit:(uint16_t)value {
+    if (self.isFrozen) {
+        @throw [NSException exceptionWithName:NSObjectInaccessibleException
+                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
+                                     userInfo:nil];
+    }
+    _limit = value;
+}
+
+- (ARTQueryDirection)direction {
+    return _direction;
+}
+
+- (void)setDirection:(ARTQueryDirection)value {
+    if (self.isFrozen) {
+        @throw [NSException exceptionWithName:NSObjectInaccessibleException
+                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
+                                     userInfo:nil];
+    }
+    _direction = value;
+}
+
 @end
 
-@implementation ARTRealtimeHistoryQuery
+@implementation ARTRealtimeHistoryQuery {
+    BOOL _untilAttach;
+}
 
 - (NSMutableArray *)asQueryItems:(NSError **)errorPtr {
     NSMutableArray *items = [super asQueryItems:errorPtr];
@@ -56,6 +115,19 @@ static NSString *queryDirectionToString(ARTQueryDirection direction) {
         [items addObject:[NSURLQueryItem queryItemWithName:@"fromSerial" value:self.realtimeChannel.attachSerial]];
     }
     return items;
+}
+
+- (BOOL)untilAttach {
+    return _untilAttach;
+}
+
+- (void)setUntilAttach:(BOOL)value {
+    if (self.isFrozen) {
+        @throw [NSException exceptionWithName:NSObjectInaccessibleException
+                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
+                                     userInfo:nil];
+    }
+    _untilAttach = value;
 }
 
 @end

--- a/Source/ARTRealtimePresence.m
+++ b/Source/ARTRealtimePresence.m
@@ -36,11 +36,7 @@
 }
 
 - (void)setWaitForSync:(BOOL)value {
-    if (self.isFrozen) {
-        @throw [NSException exceptionWithName:NSObjectInaccessibleException
-                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
-                                     userInfo:nil];
-    }
+    [self throwIfFrozen];
     _waitForSync = value;
 }
 

--- a/Source/ARTRealtimePresence.m
+++ b/Source/ARTRealtimePresence.m
@@ -19,7 +19,9 @@
 
 #pragma mark - ARTRealtimePresenceQuery
 
-@implementation ARTRealtimePresenceQuery
+@implementation ARTRealtimePresenceQuery {
+    BOOL _waitForSync;
+}
 
 - (instancetype)initWithLimit:(NSUInteger)limit clientId:(NSString *)clientId connectionId:(NSString *)connectionId {
     self = [super initWithLimit:limit clientId:clientId connectionId:connectionId];
@@ -27,6 +29,19 @@
         _waitForSync = true;
     }
     return self;
+}
+
+- (BOOL)waitForSync {
+    return _waitForSync;
+}
+
+- (void)setWaitForSync:(BOOL)value {
+    if (self.isFrozen) {
+        @throw [NSException exceptionWithName:NSObjectInaccessibleException
+                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
+                                     userInfo:nil];
+    }
+    _waitForSync = value;
 }
 
 @end
@@ -220,6 +235,8 @@ typedef NS_ENUM(NSUInteger, ARTPresenceSyncState) {
             });
         };
     }
+
+    query.frozen = true;
 
 dispatch_async(_queue, ^{
     switch (self->_channel.state_nosync) {

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -667,6 +667,8 @@ NS_ASSUME_NONNULL_END
             });
         };
     }
+    
+    query.frozen = true;
 
     if (query.limit > 1000) {
         if (errorPtr) {

--- a/Source/ARTRestChannel.m
+++ b/Source/ARTRestChannel.m
@@ -161,6 +161,8 @@ static const NSUInteger kIdempotentLibraryGeneratedIdLength = 9; //bytes
             });
         };
     }
+    
+    query.frozen = true;
 
     __block BOOL ret;
 dispatch_sync(_queue, ^{

--- a/Source/ARTRestPresence.m
+++ b/Source/ARTRestPresence.m
@@ -58,11 +58,7 @@
 }
 
 - (void)setLimit:(NSUInteger)value {
-    if (self.isFrozen) {
-        @throw [NSException exceptionWithName:NSObjectInaccessibleException
-                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
-                                     userInfo:nil];
-    }
+    [self throwIfFrozen];
     _limit = value;
 }
 
@@ -71,11 +67,7 @@
 }
 
 - (void)setClientId:(NSString *)value {
-    if (self.isFrozen) {
-        @throw [NSException exceptionWithName:NSObjectInaccessibleException
-                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
-                                     userInfo:nil];
-    }
+    [self throwIfFrozen];
     _clientId = value;
 }
 
@@ -84,11 +76,7 @@
 }
 
 - (void)setConnectionId:(NSString *)value {
-    if (self.isFrozen) {
-        @throw [NSException exceptionWithName:NSObjectInaccessibleException
-                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
-                                     userInfo:nil];
-    }
+    [self throwIfFrozen];
     _connectionId = value;
 }
 

--- a/Source/ARTRestPresence.m
+++ b/Source/ARTRestPresence.m
@@ -14,7 +14,11 @@
 #import "ARTChannel.h"
 #import "ARTDataQuery.h"
 
-@implementation ARTPresenceQuery
+@implementation ARTPresenceQuery {
+    NSUInteger _limit;
+    NSString *_clientId;
+    NSString *_connectionId;
+}
 
 - (instancetype)init {
     return [self initWithClientId:nil connectionId:nil];
@@ -47,6 +51,45 @@
     [items addObject:[NSURLQueryItem queryItemWithName:@"limit" value:[NSString stringWithFormat:@"%lu", (unsigned long)self.limit]]];
 
     return items;
+}
+
+- (NSUInteger)limit {
+    return _limit;
+}
+
+- (void)setLimit:(NSUInteger)value {
+    if (self.isFrozen) {
+        @throw [NSException exceptionWithName:NSObjectInaccessibleException
+                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
+                                     userInfo:nil];
+    }
+    _limit = value;
+}
+
+- (NSString *)clientId {
+    return _clientId;
+}
+
+- (void)setClientId:(NSString *)value {
+    if (self.isFrozen) {
+        @throw [NSException exceptionWithName:NSObjectInaccessibleException
+                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
+                                     userInfo:nil];
+    }
+    _clientId = value;
+}
+
+- (NSString *)connectionId {
+    return _connectionId;
+}
+
+- (void)setConnectionId:(NSString *)value {
+    if (self.isFrozen) {
+        @throw [NSException exceptionWithName:NSObjectInaccessibleException
+                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
+                                     userInfo:nil];
+    }
+    _connectionId = value;
 }
 
 @end
@@ -130,6 +173,8 @@ NS_ASSUME_NONNULL_END
         };
     }
 
+    query.frozen = true;
+    
     if (query.limit > 1000) {
         if (errorPtr) {
             *errorPtr = [NSError errorWithDomain:ARTAblyErrorDomain
@@ -175,6 +220,8 @@ dispatch_async(_queue, ^{
         };
     }
 
+    query.frozen = true;
+    
     if (query.limit > 1000) {
         if (errorPtr) {
             *errorPtr = [NSError errorWithDomain:ARTAblyErrorDomain

--- a/Source/ARTStats.m
+++ b/Source/ARTStats.m
@@ -41,11 +41,7 @@ static NSString *statsUnitToString(ARTStatsGranularity unit) {
 }
 
 - (void)setUnit:(ARTStatsGranularity)value {
-    if (self.isFrozen) {
-        @throw [NSException exceptionWithName:NSObjectInaccessibleException
-                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
-                                     userInfo:nil];
-    }
+    [self throwIfFrozen];
     _unit = value;
 }
 

--- a/Source/ARTStats.m
+++ b/Source/ARTStats.m
@@ -1,7 +1,9 @@
 #import "ARTStats.h"
 #import "ARTDataQuery+Private.h"
 
-@implementation ARTStatsQuery
+@implementation ARTStatsQuery {
+    ARTStatsGranularity _unit;
+}
 
 - (instancetype)init {
     if (self = [super init]) {
@@ -32,6 +34,19 @@ static NSString *statsUnitToString(ARTStatsGranularity unit) {
     }
     [items addObject:[NSURLQueryItem queryItemWithName:@"unit" value:statsUnitToString(self.unit)]];
     return items;
+}
+
+- (ARTStatsGranularity)unit {
+    return _unit;
+}
+
+- (void)setUnit:(ARTStatsGranularity)value {
+    if (self.isFrozen) {
+        @throw [NSException exceptionWithName:NSObjectInaccessibleException
+                                       reason:[NSString stringWithFormat:@"%@: You can't change query after you've passed it to the receiver.", self.class]
+                                     userInfo:nil];
+    }
+    _unit = value;
 }
 
 @end

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -14,6 +14,7 @@ framework module Ably {
         header "ARTChannels+Private.h"
         header "ARTConnection+Private.h"
         header "ARTConnectionDetails+Private.h"
+        header "ARTBaseQuery.h"
         header "ARTDataQuery+Private.h"
         header "ARTDefault+Private.h"
         header "ARTEventEmitter+Private.h"

--- a/Source/include/Ably/ARTBaseQuery.h
+++ b/Source/include/Ably/ARTBaseQuery.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+
+/// :nodoc:
+@interface ARTBaseQuery : NSObject
+
+@property (nonatomic, getter=isFrozen) BOOL frozen;
+
+@end

--- a/Source/include/Ably/ARTBaseQuery.h
+++ b/Source/include/Ably/ARTBaseQuery.h
@@ -5,4 +5,6 @@
 
 @property (nonatomic, getter=isFrozen) BOOL frozen;
 
+- (void)throwIfFrozen;
+
 @end

--- a/Source/include/Ably/ARTChannelOptions.h
+++ b/Source/include/Ably/ARTChannelOptions.h
@@ -8,6 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Passes additional properties to an `ARTRestChannel` object, such as encryption.
  */
+NS_SWIFT_SENDABLE
 @interface ARTChannelOptions : NSObject
 
 /**

--- a/Source/include/Ably/ARTDataQuery.h
+++ b/Source/include/Ably/ARTDataQuery.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-
+#import <Ably/ARTBaseQuery.h>
 #import <Ably/ARTTypes.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -14,7 +14,8 @@ typedef NS_ENUM(NSUInteger, ARTQueryDirection) {
 /**
  This object is used for providing parameters into methods with paginated results.
  */
-@interface ARTDataQuery : NSObject
+NS_SWIFT_SENDABLE
+@interface ARTDataQuery : ARTBaseQuery
 
 /**
  * The time from which the data items are retrieved.
@@ -41,6 +42,7 @@ typedef NS_ENUM(NSUInteger, ARTQueryDirection) {
 /**
  This object is used for providing parameters into `ARTRealtimePresence`'s methods with paginated results.
  */
+NS_SWIFT_SENDABLE
 @interface ARTRealtimeHistoryQuery : ARTDataQuery
 
 /**

--- a/Source/include/Ably/ARTRealtimeChannel.h
+++ b/Source/include/Ably/ARTRealtimeChannel.h
@@ -154,6 +154,7 @@ ART_EMBED_INTERFACE_EVENT_EMITTER(ARTChannelEvent, ARTChannelStateChange *)
 /**
  * Describes the properties of the channel state.
  */
+NS_SWIFT_SENDABLE
 @interface ARTChannelProperties : NSObject
 /**
  * Starts unset when a channel is instantiated, then updated with the `channelSerial` from each `ARTChannelEventAttached` event that matches the channel. Used as the value for `ARTRealtimeHistoryQuery.untilAttach`.

--- a/Source/include/Ably/ARTRealtimeChannelOptions.h
+++ b/Source/include/Ably/ARTRealtimeChannelOptions.h
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Passes additional properties to an `ARTRealtimeChannel` object, such as encryption, an `ARTChannelMode` and channel parameters.
  */
+NS_SWIFT_SENDABLE
 @interface ARTRealtimeChannelOptions : ARTChannelOptions
 
 /**

--- a/Source/include/Ably/ARTRealtimePresence.h
+++ b/Source/include/Ably/ARTRealtimePresence.h
@@ -10,6 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  This object is used for providing parameters into `ARTRealtimePresence`'s methods with paginated results.
  */
+NS_SWIFT_SENDABLE
 @interface ARTRealtimePresenceQuery : ARTPresenceQuery
 
 /**

--- a/Source/include/Ably/ARTRestPresence.h
+++ b/Source/include/Ably/ARTRestPresence.h
@@ -2,6 +2,7 @@
 
 #import <Ably/ARTPresence.h>
 #import <Ably/ARTDataQuery.h>
+#import <Ably/ARTBaseQuery.h>
 
 @class ARTRestChannel;
 
@@ -10,7 +11,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  This object is used for providing parameters into `ARTRestPresence`'s methods with paginated results.
  */
-@interface ARTPresenceQuery : NSObject
+NS_SWIFT_SENDABLE
+@interface ARTPresenceQuery : ARTBaseQuery
 
 /**
  * An upper limit on the number of messages returned. The default is 100, and the maximum is 1000.

--- a/Source/include/Ably/ARTStats.h
+++ b/Source/include/Ably/ARTStats.h
@@ -30,6 +30,7 @@ typedef NS_ENUM(NSUInteger, ARTStatsGranularity) {
 /**
  This object is used for providing parameters into `ARTStats`'s methods with paginated results.
  */
+NS_SWIFT_SENDABLE
 @interface ARTStatsQuery : ARTDataQuery
 
 /**

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -1777,7 +1777,8 @@ extension ARTMessage {
     }
 
 }
-#if swift(>=6)
+
+#if hasFeature(RetroactiveAttribute)
 extension ARTRealtimeConnectionState : @retroactive CustomStringConvertible {
     public var description : String {
         return ARTRealtimeConnectionStateToStr(self)
@@ -1813,9 +1814,7 @@ extension ARTPresenceAction : @retroactive CustomStringConvertible {
         return ARTPresenceActionToStr(self)
     }
 }
-
 #else
-
 extension ARTRealtimeConnectionState : CustomStringConvertible {
     public var description : String {
         return ARTRealtimeConnectionStateToStr(self)
@@ -1851,7 +1850,6 @@ extension ARTPresenceAction : CustomStringConvertible {
         return ARTPresenceActionToStr(self)
     }
 }
-
 #endif
 
 // MARK: - Custom Nimble Matchers

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -1777,6 +1777,44 @@ extension ARTMessage {
     }
 
 }
+#if swift(>=6)
+extension ARTRealtimeConnectionState : @retroactive CustomStringConvertible {
+    public var description : String {
+        return ARTRealtimeConnectionStateToStr(self)
+    }
+}
+
+extension ARTRealtimeConnectionEvent : @retroactive CustomStringConvertible {
+    public var description : String {
+        return ARTRealtimeConnectionEventToStr(self)
+    }
+}
+
+extension ARTProtocolMessageAction : @retroactive CustomStringConvertible {
+    public var description : String {
+        return ARTProtocolMessageActionToStr(self)
+    }
+}
+
+extension ARTRealtimeChannelState : @retroactive CustomStringConvertible {
+    public var description : String {
+        return ARTRealtimeChannelStateToStr(self)
+    }
+}
+
+extension ARTChannelEvent : @retroactive CustomStringConvertible {
+    public var description : String {
+        return ARTChannelEventToStr(self)
+    }
+}
+
+extension ARTPresenceAction : @retroactive CustomStringConvertible {
+    public var description : String {
+        return ARTPresenceActionToStr(self)
+    }
+}
+
+#else
 
 extension ARTRealtimeConnectionState : CustomStringConvertible {
     public var description : String {
@@ -1813,6 +1851,8 @@ extension ARTPresenceAction : CustomStringConvertible {
         return ARTPresenceActionToStr(self)
     }
 }
+
+#endif
 
 // MARK: - Custom Nimble Matchers
 

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -3661,6 +3661,12 @@ class RealtimeClientChannelTests: XCTestCase {
                 }
             }.toNot(throwError { err in fail("\(err)"); done() })
         }
+        
+        let exception1 = tryInObjC {
+            query.untilAttach = false // frozen
+        }
+        XCTAssertNotNil(exception1)
+        XCTAssertEqual(exception1!.name, NSExceptionName.objectInaccessibleException)
     }
 
     // RTL10c

--- a/Test/Tests/RealtimeClientChannelsTests.swift
+++ b/Test/Tests/RealtimeClientChannelsTests.swift
@@ -2,12 +2,21 @@ import Ably
 import Nimble
 import XCTest
 
+#if swift(>=6)
+// Swift isn't yet smart enough to do this automatically when bridging Objective-C APIs
+extension ARTRealtimeChannels: @retroactive Sequence {
+    public func makeIterator() -> NSFastEnumerationIterator {
+        return NSFastEnumerationIterator(iterate())
+    }
+}
+#else
 // Swift isn't yet smart enough to do this automatically when bridging Objective-C APIs
 extension ARTRealtimeChannels: Sequence {
     public func makeIterator() -> NSFastEnumerationIterator {
         return NSFastEnumerationIterator(iterate())
     }
 }
+#endif
 
 class RealtimeClientChannelsTests: XCTestCase {
     // RTS2

--- a/Test/Tests/RealtimeClientChannelsTests.swift
+++ b/Test/Tests/RealtimeClientChannelsTests.swift
@@ -2,7 +2,7 @@ import Ably
 import Nimble
 import XCTest
 
-#if swift(>=6)
+#if hasFeature(RetroactiveAttribute)
 // Swift isn't yet smart enough to do this automatically when bridging Objective-C APIs
 extension ARTRealtimeChannels: @retroactive Sequence {
     public func makeIterator() -> NSFastEnumerationIterator {

--- a/Test/Tests/RealtimeClientPresenceTests.swift
+++ b/Test/Tests/RealtimeClientPresenceTests.swift
@@ -3245,6 +3245,11 @@ class RealtimeClientPresenceTests: XCTestCase {
             let params = ARTRealtimePresenceQuery()
             params.waitForSync = true
             channel.presence.get(params, callback: callback)
+            let exception = tryInObjC {
+                params.waitForSync = false // frozen
+            }
+            XCTAssertNotNil(exception)
+            XCTAssertEqual(exception!.name, NSExceptionName.objectInaccessibleException)
         }
     }
 
@@ -3547,7 +3552,13 @@ class RealtimeClientPresenceTests: XCTestCase {
         }
         XCTAssertTrue(restPresenceHistoryMethodWasCalled)
         restPresenceHistoryMethodWasCalled = false
-
+        
+        let exception1 = tryInObjC {
+            queryRealtime.untilAttach = false // frozen
+        }
+        XCTAssertNotNil(exception1)
+        XCTAssertEqual(exception1!.name, NSExceptionName.objectInaccessibleException)
+        
         waitUntil(timeout: testTimeout) { done in
             expect {
                 try channelRealtime.presence.history(queryRealtime) { _, _ in

--- a/Test/Tests/RestClientChannelTests.swift
+++ b/Test/Tests/RestClientChannelTests.swift
@@ -592,6 +592,30 @@ class RestClientChannelTests: XCTestCase {
                     XCTAssertTrue(message.extras == extras)
                     done()
                 }
+                
+                let exception1 = tryInObjC {
+                    query.limit = 1000 // frozen
+                }
+                XCTAssertNotNil(exception1)
+                XCTAssertEqual(exception1!.name, NSExceptionName.objectInaccessibleException)
+                
+                let exception2 = tryInObjC {
+                    query.start = Date() // frozen
+                }
+                XCTAssertNotNil(exception2)
+                XCTAssertEqual(exception2!.name, NSExceptionName.objectInaccessibleException)
+                
+                let exception3 = tryInObjC {
+                    query.end = Date() // frozen
+                }
+                XCTAssertNotNil(exception3)
+                XCTAssertEqual(exception3!.name, NSExceptionName.objectInaccessibleException)
+                
+                let exception4 = tryInObjC {
+                    query.direction = .forwards // frozen
+                }
+                XCTAssertNotNil(exception4)
+                XCTAssertEqual(exception4!.name, NSExceptionName.objectInaccessibleException)
             }
         }
     }
@@ -1103,9 +1127,12 @@ class RestClientChannelTests: XCTestCase {
             XCTAssertEqual(error._code, ARTDataQueryError.timestampRange.rawValue)
         })
 
-        query.direction = .forwards
+        let query2 = ARTDataQuery()
+        query2.direction = .forwards
+        query2.end = query.end
+        query2.start = query.start
 
-        expect { try channel.history(query) { _, _ in } }.to(throwError { (error: Error) in
+        expect { try channel.history(query2) { _, _ in } }.to(throwError { (error: Error) in
             XCTAssertEqual(error._code, ARTDataQueryError.timestampRange.rawValue)
         })
     }
@@ -1203,8 +1230,9 @@ class RestClientChannelTests: XCTestCase {
         query.limit = 1001
         expect { try channel.history(query, callback: { _, _ in }) }.to(throwError())
 
-        query.limit = 1000
-        expect { try channel.history(query, callback: { _, _ in }) }.toNot(throwError())
+        let query2 = ARTDataQuery()
+        query2.limit = 1000
+        expect { try channel.history(query2, callback: { _, _ in }) }.toNot(throwError())
     }
 
     // RSL3, RSP1

--- a/Test/Tests/RestClientChannelsTests.swift
+++ b/Test/Tests/RestClientChannelsTests.swift
@@ -2,12 +2,20 @@ import Ably
 import Nimble
 import XCTest
 
+#if swift(>=6)
 // Swift isn't yet smart enough to do this automatically when bridging Objective-C APIs
+extension ARTRestChannels: @retroactive Sequence {
+    public func makeIterator() -> NSFastEnumerationIterator {
+        return NSFastEnumerationIterator(iterate())
+    }
+}
+#else
 extension ARTRestChannels: Sequence {
     public func makeIterator() -> NSFastEnumerationIterator {
         return NSFastEnumerationIterator(iterate())
     }
 }
+#endif
 
 private func beAChannel(named expectedValue: String) -> Nimble.Predicate<ARTChannel> {
     return Predicate.define("be a channel with name \"\(expectedValue)\"") { actualExpression, msg -> PredicateResult in

--- a/Test/Tests/RestClientChannelsTests.swift
+++ b/Test/Tests/RestClientChannelsTests.swift
@@ -2,7 +2,7 @@ import Ably
 import Nimble
 import XCTest
 
-#if swift(>=6)
+#if hasFeature(RetroactiveAttribute)
 // Swift isn't yet smart enough to do this automatically when bridging Objective-C APIs
 extension ARTRestChannels: @retroactive Sequence {
     public func makeIterator() -> NSFastEnumerationIterator {

--- a/Test/Tests/RestClientStatsTests.swift
+++ b/Test/Tests/RestClientStatsTests.swift
@@ -111,6 +111,12 @@ class RestClientStatsTests: XCTestCase {
         let result = try queryStats(client, query)
         XCTAssertEqual(result.items.count, 3)
 
+        let exception1 = tryInObjC {
+            query.unit = .month // frozen
+        }
+        XCTAssertNotNil(exception1)
+        XCTAssertEqual(exception1!.name, NSExceptionName.objectInaccessibleException)
+        
         let totalInbound = result.items.reduce(0 as UInt) {
             $0 + $1.inbound.all.messages.count
         }


### PR DESCRIPTION
By analogy with `ARTRealtimePresenceQuery` (which causes warning in Xcode 16) I've added `NS_SWIFT_SENDABLE` to other query types as well.

Closes #1971

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced the `ARTBaseQuery` component, enhancing query capabilities within the Ably framework.
  - Added properties to various query classes, allowing for more granular control over query parameters, including start, end, limit, and direction.
  - Enhanced presence query functionality with new properties for improved control over synchronization behavior.
  - Improved handling of statistics queries with a new granularity unit.
  - Added Swift concurrency attributes to `ARTChannelOptions` and `ARTRealtimeChannelOptions` for improved interoperability.

- **Bug Fixes**
  - Improved immutability checks for query objects to prevent modifications after they are marked as "frozen."
  - Enhanced handling of `nil` values during encoding and decoding processes to prevent unexpected behavior.

- **Tests**
  - Expanded the test suite to include checks for exception handling when modifying frozen query properties, ensuring robustness and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->